### PR TITLE
If environment is not given it defaults to empty string

### DIFF
--- a/ShipwireConnector.php
+++ b/ShipwireConnector.php
@@ -56,7 +56,7 @@ class ShipwireConnector //extends Shipwire
     public static function init($username, $password, $environment = null)
     {
         self::$authorizationCode = base64_encode($username . ':' . $password);
-        if (self::$environment !== null) {
+        if (null !== $environment) {
             self::$environment = $environment;
         }
         self::$instance = null;


### PR DESCRIPTION
fixes https://github.com/flydreamers/shipwire-api/issues/6
