### PR TITLE
Fix limit when page is 0

### DIFF
--- a/base/ShipwireComponent.php
+++ b/base/ShipwireComponent.php
@@ -40,12 +40,11 @@ class ShipwireComponent
      * @throws \flydreamers\shipwire\exceptions\ShipwireConnectionException
      */
     protected function get($route, $params, $page=0, $limit=50){
-        if ($page!=false){
-            $limit = max(1,min($limit,100));
-            $page = max(0,$page);
-            $params['offset'] = $page * $limit;
-            $params['limit'] = $limit;
-        }
+        $limit = max(1,min($limit,100));
+        $page = max(0,$page);
+        $params['offset'] = $page * $limit;
+        $params['limit'] = $limit;
+
         return $this->_connector->api($route, $params, ShipwireConnector::GET, null, true);
     }
 


### PR DESCRIPTION
Loose comparison returned false when $page was 0. The comparison itself was also useless.

fixes https://github.com/flydreamers/shipwire-api/issues/25